### PR TITLE
Add TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ queue.isEmpty();
 // --> true
 ```
 
+TypeScript definitions are also provided:
+
+```typescript
+import Queue = require('queue-fifo');
+
+let stringQueue = new Queue<string>();
+let numberQueue = new Queue<number>();
+```
+
 ## API
 
 **Available methods for a queue instance:**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+declare module 'queue-fifo' {
+    class Queue<T> {
+        public isEmpty(): boolean;
+        public size(): number;
+        public clear(): void;
+        public enqueue(data: T): void;
+        public dequeue(): T | null;
+        public peek(): T | null;
+    }
+
+    export = Queue;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.5",
   "description": "Javascript implementation of a queue data structure",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "pretest": "npm run lint",
     "test": "nyc mocha",


### PR DESCRIPTION
Implements #1.

Full disclosure: I'm not an expert on writing TypeScript declarations, so it's entirely possible there's a better way to do this. I think the way the Queue class is being exposed necessitated the less-than-ideal `require` form for the import, but it's possible I just didn't find the better way to do it.

Also, I got this working locally by linking the project via `yarn link`, but I'm not sure if the `typings` bit I added to `package.json` will correctly include the definitions next time you publish. Still need to vet some of this, just not sure how.